### PR TITLE
Dua support (NOTE: assumed better-args has been merged)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Lua files
+[*.lua]
+indent_style = space
+indent_size = 2
+
+# JSON, YAML
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 4
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A plugin for [yazi](https://github.com/sxyazi/yazi) to calculate the size of the
 ## Requirements
 
 - `du` (default) on Linux. macOS
-- For Windows and macOS users, please install [dua](https://github.com/Byron/dua-cli) (a fast disk usage analyzer written in Rust) and ensure it is in your PATH.  For Linux and macOS users, `dua` may be used as well -- it offers better performance than `du` on large folders.
+- [dua](https://github.com/Byron/dua-cli) is an alternative solution providing a fast disk usage analyzer written in Rust. If you choose this option, install per the instructions and ensure it is in your PATH. It offers better performance than `du` on large folders.
 
 ## Installation
 
@@ -36,7 +36,7 @@ You can pass arguments to the plugin to modify its behavior.
 
 #### clipboard
 
-If you want to copy the result to the clipboard, add `clipboard` as an argument (note the space after `--`):  `plugin what-size -- clipboard`
+If you want to copy the result to the clipboard, add `clipboard` as an argument (note the space after `--`): `plugin what-size -- clipboard`
 
 ```toml
 [manager]
@@ -47,7 +47,7 @@ prepend_keymap = [
 
 #### dua
 
-If you want to use `dua` instead of `du`, add `dua` as an argument (note the space after `--`):  `plugin what-size -- dua`
+If you want to use `dua` instead of `du`, add `dua` as an argument (note the space after `--`): `plugin what-size -- dua`
 
 ```toml
 [manager]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A plugin for [yazi](https://github.com/sxyazi/yazi) to calculate the size of the
 
 ## Requirements
 
-- `du` on Linux, PowerShell on Windows.
-- macOS support is planned (via `du` utility, too).
+- `du` (default) on Linux/macOS, PowerShell on Windows.
+- [dua](https://github.com/Byron/dua-cli) (optional): If `dua` is found in your PATH, it will be used automatically for better performance. Ensure it's installed if you want to use it.
 
 ## Installation
 
@@ -42,6 +42,17 @@ If you want to copy the result to clipboard, you can use the `clipboard` argumen
 [manager]
 prepend_keymap = [
   { on   = [ ".", "s" ], run  = "plugin what-size -- clipboard", desc = "Calc size of selection or cwd" },
+]
+```
+
+#### no-dua
+
+To prevent the plugin from automatically using `dua` even if it's installed, pass the `no-dua` argument:
+
+```toml
+[manager]
+prepend_keymap = [
+  { on   = [ ".", "s" ], run  = "plugin what-size -- no-dua", desc = "Calc size (force non-dua)" },
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ prepend_keymap = [
 ]
 ```
 
+#### dua
+
+If you want to force the plugin to use `dua` to skip the `dua --version` test:
+
+```toml
+[manager]
+prepend_keymap = [
+  { on   = [ ".", "s" ], run  = "plugin what-size -- dua", desc = "Calc size of selection or cwd" },
+]
+```
+
 #### no-dua
 
 To prevent the plugin from automatically using `dua` even if it's installed, pass the `no-dua` argument:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A plugin for [yazi](https://github.com/sxyazi/yazi) to calculate the size of the
 
 ## Requirements
 
-- `du` (default) on Linux. macOS
-- [dua](https://github.com/Byron/dua-cli) is an alternative solution providing a fast disk usage analyzer written in Rust. If you choose this option, install per the instructions and ensure it is in your PATH. It offers better performance than `du` on large folders.
+- `du` on Linux, PowerShell on Windows.
+- macOS support is planned (via `du` utility, too).
 
 ## Installation
 
@@ -21,7 +21,7 @@ ya pack -a 'pirafrank/what-size'
 
 ## Usage
 
-Add this to your `~/.config/yazi/keymap.toml`:
+Add this to your `~/.config/yazi/keymap.toml`: 
 
 ```toml
 [manager]
@@ -36,23 +36,12 @@ You can pass arguments to the plugin to modify its behavior.
 
 #### clipboard
 
-If you want to copy the result to the clipboard, add `clipboard` as an argument (note the space after `--`): `plugin what-size -- clipboard`
+If you want to copy the result to clipboard, you can use the `clipboard` argument:
 
 ```toml
 [manager]
 prepend_keymap = [
   { on   = [ ".", "s" ], run  = "plugin what-size -- clipboard", desc = "Calc size of selection or cwd" },
-]
-```
-
-#### dua
-
-If you want to use `dua` instead of `du`, add `dua` as an argument (note the space after `--`): `plugin what-size -- dua`
-
-```toml
-[manager]
-prepend_keymap = [
-  { on   = [ ".", "s" ], run  = "plugin what-size -- dua", desc = "Calc size of selection or cwd" },
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ A plugin for [yazi](https://github.com/sxyazi/yazi) to calculate the size of the
 
 ## Requirements
 
-- `du` on Linux, PowerShell on Windows.
-
-macOS support is planned (via `du` utility, too).
+- `du` (default) on Linux. macOS
+- For Windows and macOS users, please install [dua](https://github.com/Byron/dua-cli) (a fast disk usage analyzer written in Rust) and ensure it is in your PATH.  For Linux and macOS users, `dua` may be used as well -- it offers better performance than `du` on large folders.
 
 ## Installation
 
@@ -31,19 +30,29 @@ prepend_keymap = [
 ]
 ```
 
-If you want to copy the result to clipboard, you can add `--clipboard` or `-c` as 2nd positional argument:
+### Arguments
+
+You can pass arguments to the plugin to modify its behavior.
+
+#### clipboard
+
+If you want to copy the result to the clipboard, add `clipboard` as an argument (note the space after `--`):  `plugin what-size -- clipboard`
 
 ```toml
 [manager]
 prepend_keymap = [
-  { on   = [ ".", "s" ], run  = "plugin what-size -- '--clipboard'", desc = "Calc size of selection or cwd" },
+  { on   = [ ".", "s" ], run  = "plugin what-size -- clipboard", desc = "Calc size of selection or cwd" },
 ]
 ```
 
+#### dua
+
+If you want to use `dua` instead of `du`, add `dua` as an argument (note the space after `--`):  `plugin what-size -- dua`
+
 ```toml
 [manager]
 prepend_keymap = [
-  { on   = [ ".", "s" ], run  = "plugin what-size -- '-c'", desc = "Calc size of selection or cwd" },
+  { on   = [ ".", "s" ], run  = "plugin what-size -- dua", desc = "Calc size of selection or cwd" },
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ A plugin for [yazi](https://github.com/sxyazi/yazi) to calculate the size of the
 
 ## Compatibility
 
+- yazi `25.x` since commit `fce1778d911621dc57796cdfdf11dcda3c2e28de` ([link](https://github.com/pirafrank/what-size.yazi/commit/fce1778d911621dc57796cdfdf11dcda3c2e28de)).
 - yazi `0.4.x` since commit `2780de5aeef1ed16d1973dd6e0cd4d630c900d56` ([link](https://github.com/pirafrank/what-size.yazi/commit/2780de5aeef1ed16d1973dd6e0cd4d630c900d56)).
 - yazi `0.3.x` up to commit `f08f7f2d5c94958ac4cb66c51a7c24b4319c6c93` ([link](https://github.com/pirafrank/what-size.yazi/commit/f08f7f2d5c94958ac4cb66c51a7c24b4319c6c93)).
 
 ## Requirements
 
-- `du` on Linux. macOS and Windows support is planned.
+- `du` on Linux, PowerShell on Windows.
+
+macOS support is planned (via `du` utility, too).
 
 ## Installation
 
@@ -28,16 +31,43 @@ prepend_keymap = [
 ]
 ```
 
-If you want to copy the result to clipboard, you can add `--clipboard` or `-c` as first argument:
+If you want to copy the result to clipboard, you can add `--clipboard` or `-c` as 2nd positional argument:
 
 ```toml
 [manager]
 prepend_keymap = [
-  { on   = [ ".", "s" ], run  = "plugin what-size --args='--clipboard'", desc = "Calc size of selection or cwd" },
+  { on   = [ ".", "s" ], run  = "plugin what-size -- '--clipboard'", desc = "Calc size of selection or cwd" },
+]
+```
+
+```toml
+[manager]
+prepend_keymap = [
+  { on   = [ ".", "s" ], run  = "plugin what-size -- '-c'", desc = "Calc size of selection or cwd" },
 ]
 ```
 
 Change to whatever keybinding you like.
+
+## Feedback
+
+If you have any feedback, suggestions, or ideas please let me know by opening an issue.
+
+## Dev setup
+
+Check the debug config [here](https://yazi-rs.github.io/docs/plugins/overview/#debugging).
+
+To get debug logs while develoing use `ya.dbg()` in your code, then set the `YAZI_LOG` environment variable to `debug` before running Yazi.
+
+```sh
+YAZI_LOG=debug yazi
+```
+
+Logs will be saved to `~.local/state/yazi/yazi.log` file.
+
+## Contributing
+
+Contributions are welcome. Please fork the repository and submit a PR.
 
 ## License
 

--- a/main.lua
+++ b/main.lua
@@ -28,7 +28,7 @@ local function get_total_size(items)
     for _, path in ipairs(items) do
       path = path:gsub('"', '\\"')
       local ps_cmd = string.format(
-      [[powershell -Command "& { $p = '%s'; if (Test-Path $p) { if ((Get-ChildItem -Path $p -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum) { (Get-ChildItem -Path $p -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum } else { (Get-Item $p).Length } } }"]], 
+      [[powershell -Command "& { $p = '%s'; if (Test-Path $p) { if ((Get-ChildItem -Path $p -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum) { (Get-ChildItem -Path $p -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum } else { (Get-Item $p).Length } } }"]],
       path
       )
       local pipe = io.popen(ps_cmd)
@@ -70,9 +70,10 @@ local function format_size(size)
 end
 
 return {
-  entry = function(self, job)
+  -- as per doc: https://yazi-rs.github.io/docs/plugins/overview#functional-plugin
+  entry = function(_, job)
     -- defaults not to use clipboard, use it only if required by the user
-    local clipboard = job.args.clipboard or job.args[1] == '-c'
+    local clipboard = job.args.clipboard == true or job.args[1] == "--clipboard" or job.args[1] == "-c"
     local items = get_paths()
 
     local total_size = get_total_size(items)
@@ -87,7 +88,7 @@ return {
     ya.notify {
       title = "What size",
       content = notification_content,
-      timeout = 5,
+      timeout = 4,
     }
   end,
 }

--- a/main.lua
+++ b/main.lua
@@ -200,13 +200,14 @@ return {
   entry = function(_, job)
     local args = parse_args(job, {
       clipboard = { default = false, aliases = {"-c", "clipboard"} },
+      dua = { default = false, aliases = {"dua"} },
       no_dua = { default = false, aliases = {"no-dua"} }
     })
 
     local items = get_paths()
     local total_size = nil
 
-    local use_dua = not args.no_dua and is_dua_present()
+    local use_dua = args.dua or (not args.no_dua and is_dua_present())
 
     if use_dua then
       total_size = get_total_size_dua(items)

--- a/main.lua
+++ b/main.lua
@@ -17,29 +17,88 @@ local get_paths = ya.sync(function()
   return paths
 end)
 
--- Function to get total size from dua output
--- dua output format: "\u{1b}[32m1026520530 b\u{1b}[39m \u{1b}[36manythingllm-desktop\u{1b}[39m\n"
-local function get_dua_total_size(stdout)
-  local lines = {}
-  for line in stdout:gmatch("[^\n]+") do lines[#lines + 1] = line end
-  local last_line = lines[#lines]
-  local size_str = last_line:match("(%d+) b")
-  return tonumber(size_str)
+-- Function to parse job arguments based on expected definitions
+-- Parses arguments passed to the Yazi plugin via `job.args`.
+-- Handles:
+-- 1. Default values defined in `expected_args`.
+-- 2. Named arguments parsed by Yazi (e.g., `--clipboard` becomes `job.args.clipboard = true`).
+--    These take precedence.
+-- 3. Positional arguments that match an expected argument name or its aliases (e.g., `clipboard` or `-c`).
+--    These are treated as boolean flags (set to true) if not already set by a named argument.
+--
+-- `job`: The job object passed to the plugin's entry function.
+-- `expected_args`: A table defining the expected arguments.
+--   Format: { arg_name = { default = default_value, aliases = {"alias1", "alias2"} }, ... }
+--   `aliases` is optional.
+--
+-- Assumes `expected_args = { clipboard = { default = false, aliases = {"-c", "clipboard"} } }`.
+--
+-- | Command                           | `job.args` (Yazi)         | `parsed_args` (Output) | Notes                                                                  |
+-- | :-------------------------------- | :------------------------ | :--------------------- | :--------------------------------------------------------------------- |
+-- | `plugin what-size -- --clipboard` | `{ clipboard=true }`      | `{ clipboard=true }`   | Yazi parses `--clipboard`. Function uses it.                           |
+-- | `plugin what-size -- clipboard`   | `{ args[1]="clipboard" }` | `{ clipboard=true }`   | Yazi parses positional. Function finds alias.                            |
+-- | `plugin what-size -- -c`          | `{ args[1]="-c" }`        | `{ clipboard=true }`   | Yazi parses positional. Function finds alias.                            |
+-- | `plugin what-size --clipboard`    | `{ }`                     | `{ clipboard=false }`  | Yazi *fails* to parse `--clipboard` due to following `--`. Default used. |
+-- | `plugin what-size -c --`          | `{ args[1]="-c" }`        | `{ clipboard=true }`   | Yazi parses positional `-c`. Function finds alias.                       |
+-- | `plugin what-size clipboard`      | `{ args[1]="clipboard" }` | `{ clipboard=true }`   | Yazi parses positional `clipboard`. Function finds alias.                |
+local function parse_args(job, expected_args)
+  local parsed_args = {}
+
+  ya.dbg("Parsing args:", { job_args = job.args, expected_args = expected_args })
+
+  -- Set defaults
+  for name, config in pairs(expected_args) do
+    parsed_args[name] = config.default
+  end
+
+  ya.dbg("Args after defaults:", parsed_args)
+
+  -- Check named arguments provided by Yazi (e.g., --clipboard -> job.args.clipboard = true)
+  for name, config in pairs(expected_args) do
+    -- Prioritize Yazi's named args parsing
+    if job.args[name] ~= nil then
+      ya.dbg("Found named arg:", { name = name, value = job.args[name], overriding_default = parsed_args[name] })
+      parsed_args[name] = job.args[name] -- Handles --arg=value and --arg (sets to true)
+    end
+  end
+
+  -- Check positional arguments for aliases or full names used as flags
+  -- Handles cases like `plugin what-size -- clipboard` or `plugin what-size -- -c`
+  for i, arg_val in ipairs(job.args) do
+    ya.dbg("Checking positional arg:", { index = i, value = arg_val })
+    for name, config in pairs(expected_args) do
+      -- Check if the positional arg matches the name or an alias
+      local matched = false
+      if arg_val == name then
+        ya.dbg("Positional arg matches name:", { name = name })
+        matched = true
+      elseif config.aliases then
+        for _, alias in ipairs(config.aliases) do
+          if arg_val == alias then
+            ya.dbg("Positional arg matches alias:", { alias = alias, for_name = name })
+            matched = true
+            break
+          end
+        end
+      end
+
+      -- If matched and not already set by a named arg, set to true (treat as flag)
+      if matched and job.args[name] == nil then
+        ya.dbg("Setting flag from positional arg:", { name = name, value = true })
+        parsed_args[name] = true
+        goto next_positional -- Avoid matching the same positional arg for multiple expected args
+      end
+    end
+    ::next_positional::
+  end
+
+  ya.dbg("Final parsed args:", parsed_args)
+  return parsed_args
 end
 
 -- Function to get total size from output
--- Unix use `du`, Windows use PowerShell, or dua if specified
-local function get_total_size(items, use_dua)
-  -- If dua is specified, use it regardless of platform
-  if use_dua then
-    local output, err = Command("dua"):args({"--format", "bytes"}):args(items):output()
-    if not output or not output.stdout then
-      ya.err("Failed to run dua: " .. (err and err.message or "unknown error"))
-      return nil
-    end
-    return get_dua_total_size(output.stdout)
-  end
-
+-- Unix use `du`, Windows use PowerShell
+local function get_total_size(items)
   -- Otherwise use platform-specific commands
   local is_windows = package.config:sub(1,1) == '\\'
 
@@ -92,29 +151,13 @@ end
 return {
   -- as per doc: [https://yazi-rs.github.io/docs/plugins/overview#functional-plugin](https://yazi-rs.github.io/docs/plugins/overview#functional-plugin)
   entry = function(_, job)
-    -- Check for arguments
-    local clipboard = false
-    local use_dua = false
-    
-    -- Parse arguments
-    for _, arg in ipairs(job.args) do
-      if arg == "--clipboard" or arg == "-c" or arg == "clipboard" then
-        clipboard = true
-      elseif arg == "--dua" or arg == "dua" then
-        use_dua = true
-      end
-    end
-    
-    local items = get_paths()
-
-    ya.dbg({
-      items = items,
-      job_args = job.args,
-      use_dua = use_dua,
-      clipboard = clipboard
+    local args = parse_args(job, {
+      clipboard = { default = false, aliases = {"-c", "clipboard"} } 
     })
 
-    local total_size = get_total_size(items, use_dua)
+    local items = get_paths()
+
+    local total_size = get_total_size(items)
     
     if not total_size then
       ya.err("Failed to get total size")
@@ -124,7 +167,7 @@ return {
     local formatted_size = format_size(total_size)
 
     local notification_content = "Total size: " .. formatted_size
-    if clipboard then
+    if args.clipboard then
       ya.clipboard(formatted_size)
       notification_content = notification_content .. "\nCopied to clipboard."
     end


### PR DESCRIPTION
This dynamically uses `dua` if available.  
If `-- dua` option passed, then forces `dua` (skips `dua --version`)
If `-- no-dua` option present, forces `du` (i.e. dua fails for some reason)